### PR TITLE
Add support for port 8080

### DIFF
--- a/files/default/start-all.sh
+++ b/files/default/start-all.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 while IFS=, read -r port password ; do
-  docker run -p "${port}":22 -h dobc --rm -e DOBC_PASSWORD="${password}" \
+  docker run \
+    -p "330${port}":22 \
+    -p "340${port}":8080 \
+    -h dobc --rm -e DOBC_PASSWORD="${password}" \
     --name=dobc-"${port}" -d \
-    --device-write-bps /dev/vda:20mb \
-    -c 10 -m 128m \
+    --device-write-bps /dev/sda:20mb \
     osuosl/dobc-centos
 done < "$1"

--- a/files/default/start-container.sh
+++ b/files/default/start-container.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 while IFS=, read -r port password ; do
   if [ "$2" == "$port" ] ; then
-    docker run -p "${port}":22 -h dobc --rm -e DOBC_PASSWORD="${password}" \
+    docker run \
+      -p "330${port}":22 \
+      -p "340${port}":8080 \
+      -h dobc --rm -e DOBC_PASSWORD="${password}" \
       --name=dobc-"${port}" -d \
       --device-write-bps /dev/vda:20mb \
-      -c 10 -m 128m \
       osuosl/dobc-centos
   fi
 done < "$1"

--- a/test/cookbooks/dobc_test/files/default/passwords.csv
+++ b/test/cookbooks/dobc_test/files/default/passwords.csv
@@ -1,2 +1,2 @@
-33000,password
-33001,passw0rd
+00,password
+01,passw0rd

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -13,7 +13,7 @@ end
 end
 
 describe command('docker ps --format "{{.Names}}:{{.Status}}"') do
-  its(:stdout) { should match(/^dobc-3300[01]:Up/) }
+  its(:stdout) { should match(/^dobc-0[01]:Up/) }
 end
 
 ssh_cmd = 'sshpass -p password ssh -p 33000 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ' \
@@ -24,16 +24,16 @@ describe command(ssh_cmd) do
   its(:stdout) { should match(/^dobc$/) }
 end
 
-describe command('docker stop dobc-33000') do
+describe command('docker stop dobc-00') do
   its(:exit_status) { should eq 0 }
 end
 
-describe command('/usr/local/bin/start-container.sh /root/passwords.csv 33000') do
+describe command('/usr/local/bin/start-container.sh /root/passwords.csv 00') do
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker ps --format "{{.Names}}:{{.Status}}"') do
-  its(:stdout) { should match(/^dobc-3300[01]:Up/) }
+  its(:stdout) { should match(/^dobc-0[01]:Up/) }
 end
 
 describe command('/usr/local/bin/stop-all.sh /root/passwords.csv') do
@@ -41,5 +41,5 @@ describe command('/usr/local/bin/stop-all.sh /root/passwords.csv') do
 end
 
 describe command('docker ps --format "{{.Names}}:{{.Status}}"') do
-  its(:stdout) { should_not match(/^dobc-3300[01]:Up/) }
+  its(:stdout) { should_not match(/^dobc-0[01]:Up/) }
 end


### PR DESCRIPTION
This adds support for accessing the containers via port 8080 for use with the
flask application. This required and an adjustment where we just use the last
two digits of the port to signify which port the container uses. The ports
prefixed with 330XX are for ssh and ports prefixed with 340XX are for the flask
application port.

In addition, I'm removing the cpu and memory constraints as they seem to be what
was causing the problem before at the last DOBC.