### PR TITLE
Setup MySQL containers for each shell container

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,4 +1,6 @@
 ---
+driver:
+  flavor_ref: 'm1.xlarge'
 suites:
   - name: default
     run_list:

--- a/files/default/start-all.sh
+++ b/files/default/start-all.sh
@@ -1,10 +1,22 @@
 #!/bin/bash
 while IFS=, read -r port password ; do
+  docker run -d --rm \
+    --name=mysql-"${port}" \
+    -e MYSQL_ROOT_PASSWORD=dobc \
+    mariadb:10.3 \
+    --key_buffer=16M \
+    --innodb_buffer_pool_size=32M \
+    --query_cache_size=16M \
+    --sort_buffer=1M \
+    --read_buffer=60K \
+    --tmp_table=8M \
+    --max_connections=10
   docker run \
     -p "330${port}":22 \
     -p "340${port}":8080 \
     -h dobc --rm -e DOBC_PASSWORD="${password}" \
     --name=dobc-"${port}" -d \
+    --link mysql-"${port}":mysql \
     --device-write-bps /dev/sda:20mb \
     osuosl/dobc-centos
 done < "$1"

--- a/files/default/start-mysql.sh
+++ b/files/default/start-mysql.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+while IFS=, read -r port password ; do
+  if [ "$2" == "$port" ] ; then
+    docker run -d --rm \
+      --name=mysql-"${port}" \
+      -e MYSQL_ROOT_PASSWORD=dobc \
+      mariadb:10.3 \
+      --key_buffer=16M \
+      --innodb_buffer_pool_size=32M \
+      --query_cache_size=16M \
+      --sort_buffer=1M \
+      --read_buffer=60K \
+      --tmp_table=8M \
+      --max_connections=10
+  fi
+done < "$1"

--- a/files/default/stop-all.sh
+++ b/files/default/stop-all.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 while IFS=, read -r port password; do
   docker stop dobc-"${port}"
+  docker stop mysql-"${port}"
 done < "$1"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,7 @@ include_recipe 'firewall::docker'
 %w(
   start-all.sh
   start-container.sh
+  start-mysql.sh
   stop-all.sh
 ).each do |file|
   cookbook_file ::File.join('/usr/local/bin', file) do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -10,6 +10,7 @@ describe 'dobc::default' do
   %w(
     start-all.sh
     start-container.sh
+    start-mysql.sh
     stop-all.sh
   ).each do |file|
     it do

--- a/test/integration/default/serverspec/server_spec.rb
+++ b/test/integration/default/serverspec/server_spec.rb
@@ -6,7 +6,7 @@ describe command('/usr/local/bin/start-all.sh /root/passwords.csv') do
   its(:exit_status) { should eq 0 }
 end
 
-%w(33000 33001).each do |p|
+%w(33000 33001 34000 34001).each do |p|
   describe port(p) do
     it { should be_listening }
   end
@@ -17,23 +17,34 @@ describe command('docker ps --format "{{.Names}}:{{.Status}}"') do
 end
 
 ssh_cmd = 'sshpass -p password ssh -p 33000 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ' \
-          'dobc@localhost hostname'
+          'dobc@localhost'
 
-describe command(ssh_cmd) do
+describe command("#{ssh_cmd} hostname") do
   its(:exit_status) { should eq 0 }
   its(:stdout) { should match(/^dobc$/) }
 end
 
-describe command('docker stop dobc-00') do
+describe command("#{ssh_cmd} \"sleep 5 ; mysql -h'172.17.0.2' -P'3306' -uroot -p'dobc' -e exit\"") do
   its(:exit_status) { should eq 0 }
+end
+
+%w(dobc mysql).each do |c|
+  describe command("docker stop #{c}-00") do
+    its(:exit_status) { should eq 0 }
+  end
 end
 
 describe command('/usr/local/bin/start-container.sh /root/passwords.csv 00') do
   its(:exit_status) { should eq 0 }
 end
 
+describe command('/usr/local/bin/start-mysql.sh /root/passwords.csv 00') do
+  its(:exit_status) { should eq 0 }
+end
+
 describe command('docker ps --format "{{.Names}}:{{.Status}}"') do
   its(:stdout) { should match(/^dobc-0[01]:Up/) }
+  its(:stdout) { should match(/^mysql-0[01]:Up/) }
 end
 
 describe command('/usr/local/bin/stop-all.sh /root/passwords.csv') do
@@ -42,4 +53,5 @@ end
 
 describe command('docker ps --format "{{.Names}}:{{.Status}}"') do
   its(:stdout) { should_not match(/^dobc-0[01]:Up/) }
+  its(:stdout) { should_not match(/^mysql-0[01]:Up/) }
 end


### PR DESCRIPTION
This creates a MariaDB (MySQL) container for each shell container and links it
up using docker. MySQL has been tuned so that it uses the least amount of memory
as possible. I also added a script to start individual MySQL containers as
needed.

The dobc-centos container has an alias for the 'mysql' command which
automatically uses the environment variables which the MariaDB container has for
connecting up without needing to know the password. In addition, I've bumped up
the flavor to match the size that we use in production to ensure we have enough
memory for 100 instances of each.