### PR TITLE
Chef 14 compatibility fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,11 +11,5 @@ Style/NumericLiteralPrefix:
 Metrics/LineLength:
   Max: 120
 
-Style/IfUnlessModifier:
-  MaxLineLength: 120
-
-Style/WhileUntilModifier:
-  MaxLineLength: 120
-
 Metrics/BlockLength:
   Enabled: false

--- a/files/default/start-all.sh
+++ b/files/default/start-all.sh
@@ -3,6 +3,7 @@ while IFS=, read -r port password ; do
   docker run -d --rm \
     --name=mysql-"${port}" \
     -e MYSQL_ROOT_PASSWORD=dobc \
+    -e MYSQL_INITDB_SKIP_TZINFO=1 \
     mariadb:10.4 \
     --key_buffer=16M \
     --innodb_buffer_pool_size=32M \

--- a/files/default/start-mysql.sh
+++ b/files/default/start-mysql.sh
@@ -4,6 +4,7 @@ while IFS=, read -r port password ; do
     docker run -d --rm \
       --name=mysql-"${port}" \
       -e MYSQL_ROOT_PASSWORD=dobc \
+      -e MYSQL_INITDB_SKIP_TZINFO=1 \
       mariadb:10.4 \
       --key_buffer=16M \
       --innodb_buffer_pool_size=32M \

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,13 +1,11 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-ChefSpec::Coverage.start! { add_filter 'dobc' }
-
 CENTOS_7 = {
   platform: 'centos',
-  version: '7.4.1708',
+  version: '7',
 }.freeze
 
 RSpec.configure do |config|
-  config.log_level = :fatal
+  config.log_level = :warn
 end


### PR DESCRIPTION
**Old ChefDK (before)**
- [x] Ensure all ChefSpec tests pass
- [x] Ensure all Inspec tests pass

**New ChefDK**
- [x] Ensure cookstyle is passing
- [x] Apply foodcritic fixes
- [x] Ensure `rake` passes
- [x] Ensure all Inspec tests pass

**Old ChefDK (after)**
- [x] Repeat all tests above using old ChefDK

The new `check-mysql.sh` script verifies connection to MySQL with a timeout (it seems to take 60-240s for MariaDB to start up). This was causing InSpec to occasionally fail.